### PR TITLE
feat: H264/JPEG 깊이 처리 통합 및 JPEG <-> H264 Fallback 기능 구현

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,8 +22,20 @@
       font-size: 14px;
       line-height: 1.2;
       z-index: 1000;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
   ">
     <div id="decode-fps">Decode FPS: --</div>
     <div id="render-fps">Render FPS: --</div>
+    <div id="jpeg-fallback-option">
+      <input type="checkbox" id="jpeg-fallback-checkbox">
+      <label for="jpeg-fallback-checkbox">JPEG Fallback</label>
+    </div>
+    <div id="ws-state-console">
+      <div id="ws-state-console-text">WS State: --</div>
+      <input type="button" id="ws-connect-button" value="Connect">
+      <input type="button" id="ws-disconnect-button" value="Disconnect">
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Backend 변경사항:
  - render_loop_jpeg에서 NDC [-1,1] → [0,1] 정규화로 변경
  - H264와 동일한 logarithmic depth 처리 방식 적용

  Frontend 변경사항:
  - 경로별 깊이 텍스처 동적 생성 (recreateDepthTexture)
  - H264: ImageBitmap + UnsignedByteType (기존 방식 유지)
  - JPEG: Uint16Array + HalfFloatType (직접 float16 사용)
  - 모드 전환 시 자동 텍스처 타입 변경